### PR TITLE
Enable StrictMode

### DIFF
--- a/metrica-sample-android/app/src/main/java/com/yandex/sample/metrica/Application.java
+++ b/metrica-sample-android/app/src/main/java/com/yandex/sample/metrica/Application.java
@@ -1,5 +1,8 @@
 package com.yandex.sample.metrica;
 
+import android.os.Build;
+import android.os.StrictMode;
+
 import com.yandex.metrica.YandexMetrica;
 import com.yandex.metrica.YandexMetricaConfig;
 

--- a/metrica-sample-android/app/src/main/java/com/yandex/sample/metrica/Application.java
+++ b/metrica-sample-android/app/src/main/java/com/yandex/sample/metrica/Application.java
@@ -27,6 +27,7 @@ public class Application extends android.app.Application {
 
     @Override
     public void onCreate() {
+        enableStrictMode();
         super.onCreate();
 
         /* Replace API_KEY with your unique API key. Please, read official documentation how to obtain one:
@@ -37,5 +38,20 @@ public class Application extends android.app.Application {
 
         //If AppMetrica received referrer broadcast our own MyTrackerReceiver print it to log
         YandexMetrica.registerReferrerBroadcastReceivers(new MyTrackerReceiver());
+    }
+
+    private void enableStrictMode() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD) {
+            StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder()
+                    .detectAll()
+                    .penaltyLog()
+                    .penaltyDeath()
+                    .build());
+            StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
+                    .detectAll()
+                    .penaltyLog()
+                    .penaltyDeath()
+                    .build());
+        }
     }
 }

--- a/metrica-sample-android/app/src/main/java/com/yandex/sample/metrica/Application.java
+++ b/metrica-sample-android/app/src/main/java/com/yandex/sample/metrica/Application.java
@@ -48,13 +48,13 @@ public class Application extends android.app.Application {
             StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder()
                     .detectAll()
                     .penaltyLog()
-                    // Not recommended: you can comment penaltyDeath() and app will not crash
+                    // you can comment penaltyDeath() and app will not crash (Not recommended)
                     .penaltyDeath()
                     .build());
             StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
                     .detectAll()
                     .penaltyLog()
-                    // Not recommended: you can comment penaltyDeath() and app will not crash
+                    // you can comment penaltyDeath() and app will not crash (Not recommended)
                     .penaltyDeath()
                     .build());
         }

--- a/metrica-sample-android/app/src/main/java/com/yandex/sample/metrica/Application.java
+++ b/metrica-sample-android/app/src/main/java/com/yandex/sample/metrica/Application.java
@@ -48,11 +48,13 @@ public class Application extends android.app.Application {
             StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder()
                     .detectAll()
                     .penaltyLog()
+                    // Not recommended: you can comment penaltyDeath() and app will not crash
                     .penaltyDeath()
                     .build());
             StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
                     .detectAll()
                     .penaltyLog()
+                    // Not recommended: you can comment penaltyDeath() and app will not crash
                     .penaltyDeath()
                     .build());
         }


### PR DESCRIPTION
Will help detect Strict Errors such as io/networking on main thread/ activity or cursor leaks/ etc when testing Metrica library. 
